### PR TITLE
Support all variants of get command

### DIFF
--- a/memcached/server.go
+++ b/memcached/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"strconv"
+	"strings"
 )
 
 const VERSION = "0.0.0"
@@ -104,7 +105,12 @@ func (c *conn) handleRequest() error {
 	}
 	switch line[0] {
 	case 'g':
-		key := string(line[4:]) // get
+		f := strings.Fields(string(line))
+		if len(f) != 2 {
+			return Error
+		}
+		key := f[1]
+
 		getter, ok := c.server.Handler.(Getter)
 		if !ok {
 			return Error


### PR DESCRIPTION
According to https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L62 "get", "gets", "gat", and "gats" variants are supported